### PR TITLE
test: make habitEmptyView test work properly in unix based systems

### DIFF
--- a/src/test/java/org/example/studyplanner/KanbanViewTest.java
+++ b/src/test/java/org/example/studyplanner/KanbanViewTest.java
@@ -140,7 +140,7 @@ class KanbanViewTest {
     void habitEmptyView() throws Exception {
         try{
             String response = kanbanView.kanbanView();
-            List<String> splitResponse= List.of(response.split("\r\n"));
+            List<String> splitResponse= List.of(response.split(System.lineSeparator()));
             int count = 0;
             for(String str : splitResponse){
                 if(str.contains("No material found")){


### PR DESCRIPTION
The habitEmptyView test is failing on Unix-based operating systems due to the hardcoded line separator, this commit fixes it